### PR TITLE
create SlowTest annotation and check timeout during running test code

### DIFF
--- a/src/test/java/com/jinow/auth/annotation/SlowTest.java
+++ b/src/test/java/com/jinow/auth/annotation/SlowTest.java
@@ -1,0 +1,16 @@
+package com.jinow.auth.annotation;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Test
+@Tag("slow")
+public @interface SlowTest {
+}

--- a/src/test/java/com/jinow/auth/config/TimingExtension.java
+++ b/src/test/java/com/jinow/auth/config/TimingExtension.java
@@ -1,0 +1,47 @@
+package com.jinow.auth.config;
+
+import com.jinow.auth.annotation.SlowTest;
+import com.jinow.auth.exception.TestTimeoutException;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.util.ObjectUtils;
+
+import java.util.logging.Logger;
+
+import java.lang.reflect.Method;
+
+public class TimingExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
+
+    private static final Logger logger = Logger.getLogger(TimingExtension.class.getName());
+    private static final String START_TIME = "start time";
+    private static final long TRESHOLD = 2000;
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) throws Exception {
+        getStore(context).put(START_TIME, System.currentTimeMillis());
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext context) throws Exception {
+        Method testMethod = context.getRequiredTestMethod();
+        SlowTest annotation = testMethod.getAnnotation(SlowTest.class);
+        if (!ObjectUtils.isEmpty(annotation)) {
+            return;
+        }
+
+        long startTime = getStore(context).remove(START_TIME, long.class);
+        long duration = System.currentTimeMillis() - startTime;
+
+        if (duration > TRESHOLD) {
+            throw new TestTimeoutException(String.format("Method [%s] took %s ms.", testMethod.getName(), duration));
+        }
+
+        logger.info(() ->
+                String.format("Method [%s] took %s ms.", testMethod.getName(), duration));
+    }
+
+    private ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestMethod()));
+    }
+}

--- a/src/test/java/com/jinow/auth/exception/TestTimeoutException.java
+++ b/src/test/java/com/jinow/auth/exception/TestTimeoutException.java
@@ -1,0 +1,8 @@
+package com.jinow.auth.exception;
+
+public class TestTimeoutException extends RuntimeException {
+
+    public TestTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/jinow/auth/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/jinow/auth/jwt/service/JwtServiceTest.java
@@ -4,17 +4,16 @@ import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.jinow.auth.AuthDemoApplication;
+import com.jinow.auth.annotation.SlowTest;
+import com.jinow.auth.config.TimingExtension;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.RepetitionInfo;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.EmptySource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -22,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
 @SpringBootTest(classes = AuthDemoApplication.class)
+@ExtendWith(TimingExtension.class)
 public class JwtServiceTest {
 
     @Autowired
@@ -37,6 +37,7 @@ public class JwtServiceTest {
     }
 
     @Test
+    @Disabled
     public void 토큰생성() {
         String jwtToken = jwtService.createJwtToken("ca98047", "최진원");
         System.out.println(jwtToken);
@@ -75,5 +76,9 @@ public class JwtServiceTest {
         assertNotNull(decodedJWT.getIssuedAt());
     }
 
+    @SlowTest
+    public void 오래_실행되는_테스트로직() throws InterruptedException {
+        Thread.sleep(2000);
+    }
 
 }

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.displayname.generator.default = \
+    org.junit.jupiter.api.DisplayNameGenerator$ReplaceUnderscores


### PR DESCRIPTION
junit5 Test Lifecycle Callbacks 인터페이스를 구현하여,
테스트코드 실행시간이 2s 이상일시 TestTimeoutException 발생하는 로직 구현

SlowTest 어노테이션을 별도로 구성하여, 타임아웃 체크 예외 처리